### PR TITLE
Move futures dependency behind default-on "stream" feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,12 @@ readme          = "README.md"
 keywords        = ["reactive", "parametric", "binding", "event"]
 categories      = ["algorithms","asynchronous","data-structures","gui"]
 
+[features]
+default = ["stream"]
+stream = ["desync", "futures", "flo_rope", "flo_stream"]
+
 [dependencies]
-desync          = "0.7"
-futures         = "0.3"
-flo_rope        = "0.1"
-flo_stream      = "0.6"
+desync          = { version = "0.7", optional = true }
+futures         = { version = "0.3", optional = true }
+flo_rope        = { version = "0.1", optional = true }
+flo_stream      = { version = "0.6", optional = true }

--- a/src/bindref.rs
+++ b/src/bindref.rs
@@ -1,6 +1,7 @@
 use super::traits::*;
 use super::binding::*;
 use super::computed::*;
+#[cfg(feature = "stream")]
 use super::bind_stream::*;
 
 use std::sync::*;
@@ -114,6 +115,7 @@ impl<'a, Value: 'static+Clone+PartialEq+Send+Into<Binding<Value>>> From<&'a Valu
     }
 }
 
+#[cfg(feature = "stream")]
 impl<Value: 'static+Clone+Send+PartialEq> From<StreamBinding<Value>> for BindRef<Value> {
     #[inline]
     fn from(val: StreamBinding<Value>) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,8 +106,11 @@ mod computed;
 mod bindref;
 mod notify_fn;
 mod releasable;
+#[cfg(feature = "stream")]
 mod follow;
+#[cfg(feature = "stream")]
 mod bind_stream;
+#[cfg(feature = "stream")]
 mod rope_binding;
 
 pub use self::traits::*;
@@ -115,8 +118,11 @@ pub use self::binding::*;
 pub use self::computed::*;
 pub use self::bindref::*;
 pub use self::notify_fn::*;
+#[cfg(feature = "stream")]
 pub use self::follow::*;
+#[cfg(feature = "stream")]
 pub use self::bind_stream::*;
+#[cfg(feature = "stream")]
 pub use self::rope_binding::*;
 
 ///


### PR DESCRIPTION
Currently, `flo_binding` depends on several crates, including `futures` as both a direct and transitive dependency, resulting in 40 transitive dependencies.

I added a default-on `stream` feature flag to enable stream-related types and functions. With `default-features = false`, the `follow`, `bind_stream`, and `rope_binding` modules are disabled, and `flo_binding` becomes a feather-light zero-dependency crate. 28 of 40 tests remain and all still pass.

(I'd prefer to make this feature off by default, but that would break backwards compatibility, and you seem to prefer streams to raw bindings and may object to turning streams off by default.)