### PR TITLE
[experiment] Add Signal type for values stored outside of a Binding

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -153,3 +153,45 @@ impl<'a, Value: 'static+Clone+PartialEq+Send> From<&'a Value> for Binding<Value>
         Binding::new(val.clone())
     }
 }
+
+#[derive(Clone)]
+struct NeverEqual;
+
+impl PartialEq for NeverEqual {
+    fn eq(&self, _: &Self) -> bool {
+        false
+    }
+}
+
+/// owo
+#[derive(Clone)]
+pub struct Signal {
+    binding: Binding<NeverEqual>
+}
+
+/// Sometimes you want to store a value somewhere else (not in a `Binding`).
+/// In that case, you can create a `Signal` that the value has been changed.
+/// Then each `ComputedBinding` which uses the value must `observe()` the `Signal`.
+/// Additionally, when the value is changed, the mutating function must call
+/// `Signal::emit()` as well.
+/// If either of these is forgotten, you *will* get desyncs.
+impl Signal {
+    pub fn new() -> Signal {
+        Signal {
+            binding: Binding::new(NeverEqual)
+        }
+    }
+
+    /// Each `ComputedBinding` which uses the "signalled" value must call
+    /// `Signal::observe()` before accessing the value (or after, it doesn't matter).
+    /// This ensures that the computation function is rerun when the value is changed.
+    pub fn observe(&self) {
+        self.binding.get();
+    }
+
+    /// When the value is changed, the mutating function must call
+    /// `Signal::emit()` as well.
+    pub fn emit(&self) {
+        self.binding.set(NeverEqual);
+    }
+}


### PR DESCRIPTION
> Sometimes you want to store a value somewhere else (not in a `Binding`). In that case, you can create a `Signal` that the value has been changed. Then each `ComputedBinding` which uses the value must `observe()` the `Signal`. Additionally, when the value is changed, the mutating function must call `Signal::emit()` as well. If either of these is forgotten, you *will* get desyncs.

This is a branch I created a week or two back. In my opinion, the ergonomics of a "Signal" type are poor, because the mutating function must emit the signal, and anyone reading the value must observe the signal, and forgetting either results in silently dropped updates. So I don't think it's a good fit for the library. It's an interesting exploration in the design space though.

I don't think I feel comfortable contributing actual APIs until I have more experience designing apps using property binding (which I'll be attempting soon).